### PR TITLE
8.3: import intel-ixgbe-6.2.5-1.xs8.src.rpm

### DIFF
--- a/SOURCES/0001-CP-47635-Fix-build-errors.patch
+++ b/SOURCES/0001-CP-47635-Fix-build-errors.patch
@@ -1,0 +1,35 @@
+From 474c9d655e14031f080ceca6b5485d287a7784aa Mon Sep 17 00:00:00 2001
+From: Stephen Cheng <stephen.cheng@cloud.com>
+Date: Mon, 30 Jun 2025 15:07:26 +0800
+Subject: [PATCH] CP-47635: Fix build errors
+
+/builddir/build/BUILD/intel-ixgbe-6.1.5/src/kcompat-lib.sh: line 47: /dev/stderr: Permission denied
+/builddir/build/BUILD/intel-ixgbe-6.1.5/src/kcompat-lib.sh: line 51: /dev/stderr: Permission denied
+
+Signed-off-by: Stephen Cheng <stephen.cheng@cloud.com>
+---
+ src/kcompat-lib.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+Index: intel-ixgbe-6.2.5/src/kcompat-lib.sh
+===================================================================
+--- intel-ixgbe-6.2.5.orig/src/kcompat-lib.sh
++++ intel-ixgbe-6.2.5/src/kcompat-lib.sh
+@@ -34,7 +34,7 @@ function filter-out-bad-files() {
+ 	if [ $# = 0 ]; then
+ 		die 10 "no files passed, use '-' when reading from pipe (|)"
+ 	fi
+-	local any=0 diagmsgs=/dev/stderr re=$'[\t \n]'
++	local any=0 diagmsgs=2 re=$'[\t \n]'
+ 	[ -n "${QUIET_COMPAT-}" ] && diagmsgs=/dev/null
+ 	for x in "$@"; do
+ 		if [ -e "$x" ]; then
+@@ -406,7 +406,7 @@ function config_has() {
+ function find_config_file() {
+ 	local -a CSP
+ 	local file
+-	local diagmsgs=/dev/stderr
++	local diagmsgs=2
+ 
+ 	[ -n "${QUIET_COMPAT-}" ] && diagmsgs=/dev/null
+ 

--- a/SOURCES/0001-ixgbe-Fix-memleak-in-ixgbe_configure_clsu32.patch
+++ b/SOURCES/0001-ixgbe-Fix-memleak-in-ixgbe_configure_clsu32.patch
@@ -1,0 +1,34 @@
+From 7a766381634da19fc837619b0a34590498d9d29a Mon Sep 17 00:00:00 2001
+From: Dinghao Liu <dinghao.liu@zju.edu.cn>
+Date: Sun, 3 Jan 2021 16:08:42 +0800
+Subject: [PATCH] ixgbe: Fix memleak in ixgbe_configure_clsu32
+
+When ixgbe_fdir_write_perfect_filter_82599() fails,
+input allocated by kzalloc() has not been freed,
+which leads to memleak.
+
+Signed-off-by: Dinghao Liu <dinghao.liu@zju.edu.cn>
+Reviewed-by: Paul Menzel <pmenzel@molgen.mpg.de>
+Tested-by: Tony Brelinski <tonyx.brelinski@intel.com>
+Signed-off-by: Tony Nguyen <anthony.l.nguyen@intel.com>
+---
+ src/ixgbe_main.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+Index: intel-ixgbe-6.2.5/src/ixgbe_main.c
+===================================================================
+--- intel-ixgbe-6.2.5.orig/src/ixgbe_main.c
++++ intel-ixgbe-6.2.5/src/ixgbe_main.c
+@@ -12710,8 +12710,10 @@ static int ixgbe_configure_clsu32(struct
+ 	err = ixgbe_fdir_write_perfect_filter_82599(hw, &input->filter,
+ 						    input->sw_idx, queue,
+ 						    adapter->cloud_mode);
+-	if (!err)
+-		ixgbe_update_ethtool_fdir_entry(adapter, input, input->sw_idx);
++	if (err)
++		goto err_out_w_lock;
++
++	ixgbe_update_ethtool_fdir_entry(adapter, input, input->sw_idx);
+ 	spin_unlock(&adapter->fdir_perfect_lock);
+ 
+ 	if ((uhtid != 0x800) && (adapter->jump_tables[uhtid]))

--- a/SOURCES/0001-ixgbe-fix-memory-leaks.patch
+++ b/SOURCES/0001-ixgbe-fix-memory-leaks.patch
@@ -1,0 +1,34 @@
+From 22d11eacc32cab558e2620b6aad55d07e661847c Mon Sep 17 00:00:00 2001
+From: Wenwen Wang <wenwen@cs.uga.edu>
+Date: Sun, 11 Aug 2019 15:07:47 -0500
+Subject: [PATCH] ixgbe: fix memory leaks
+
+In ixgbe_configure_clsu32(), 'jump', 'input', and 'mask' are allocated
+through kzalloc() respectively in a for loop body. Then,
+ixgbe_clsu32_build_input() is invoked to build the input. If this process
+fails, next iteration of the for loop will be executed. However, the
+allocated 'jump', 'input', and 'mask' are not deallocated on this execution
+path, leading to memory leaks.
+
+Signed-off-by: Wenwen Wang <wenwen@cs.uga.edu>
+Tested-by: Andrew Bowers <andrewx.bowers@intel.com>
+Signed-off-by: Jeff Kirsher <jeffrey.t.kirsher@intel.com>
+---
+ src/ixgbe_main.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+Index: ethernet-linux-ixgbe/src/ixgbe_main.c
+===================================================================
+--- ethernet-linux-ixgbe.orig/src/ixgbe_main.c
++++ ethernet-linux-ixgbe/src/ixgbe_main.c
+@@ -12608,6 +12608,10 @@ static int ixgbe_configure_clsu32(struct
+ 				jump->mat = nexthdr[i].jump;
+ 				adapter->jump_tables[link_uhtid] = jump;
+ 				break;
++			} else {
++				kfree(mask);
++				kfree(input);
++				kfree(jump);
+ 			}
+ 		}
+ 

--- a/SOURCES/avoid-order-1-rx-buffers.patch
+++ b/SOURCES/avoid-order-1-rx-buffers.patch
@@ -1,0 +1,23 @@
+Avoid allocating order 1 RX buffers
+
+Certain hardware includes an additional 8 byte timestamp in the frame whose
+length is added to max_frame. This exceeds the ethernet size check (1514 + 4)
+and causes the code to instead allocate larger order 1 RX buffers which causes
+excessive swiotlb usage in certain circumstances.
+
+The IXGBE_2K_TOO_SMALL_WITH_PADDING macro checks that we can fit a 1536 byte
+frame in a 2 KiB buffer so all we need to check here is that the max_frame size
+can fit in 1536 bytes.
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
+--- intel-ixgbe-6.1.5-orig/src/ixgbe_main.c	2025-09-11 16:21:42.676097266 +0100
++++ intel-ixgbe-6.1.5/src/ixgbe_main.c	2025-09-11 16:23:52.517410163 +0100
+@@ -5574,7 +5574,7 @@
+ 			set_bit(__IXGBE_RX_3K_BUFFER, &rx_ring->state);
+ 
+ 		if (IXGBE_2K_TOO_SMALL_WITH_PADDING ||
+-		    (max_frame > (ETH_FRAME_LEN + ETH_FCS_LEN)))
++		    (max_frame > IXGBE_RXBUFFER_1536))
+ 			set_bit(__IXGBE_RX_3K_BUFFER, &rx_ring->state);
+ #endif
+ #else /* !HAVE_SWIOTLB_SKIP_CPU_SYNC */

--- a/SOURCES/intel-ixgbe-5.18.6.tar.gz
+++ b/SOURCES/intel-ixgbe-5.18.6.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d12a7300af9edde140d9d0ecfe116bf4d3079d1aeb4f279e4af358ef4b6bf972
-size 526318

--- a/SOURCES/intel-ixgbe-6.2.5.tar.gz
+++ b/SOURCES/intel-ixgbe-6.2.5.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69536d0fade21ce1c3b3f684977f6b1c762d4432a93c7d38cd45da8fa7fdcab5
+size 748093

--- a/SPECS/intel-ixgbe.spec
+++ b/SPECS/intel-ixgbe.spec
@@ -1,8 +1,8 @@
-%global package_speccommit 0074de48c3f55d5541447cb7ed3f50f399e1785f
-%global usver 5.18.6
+%global package_speccommit 1d34cf61cfae78b9e61ce92d934d9641af2d885b
+%global usver 6.2.5
 %global xsver 1
 %global xsrel %{xsver}%{?xscount}%{?xshash}
-%global package_srccommit 5.18.6
+%global package_srccommit 6.2.5
 %define vendor_name Intel
 %define vendor_label intel
 %define driver_name ixgbe
@@ -20,10 +20,14 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
-Version: 5.18.6
+Version: 6.2.5
 Release: %{?xsrel}%{?dist}
 License: GPL
-Source0: intel-ixgbe-5.18.6.tar.gz
+Source0: intel-ixgbe-6.2.5.tar.gz
+Patch0: 0001-ixgbe-fix-memory-leaks.patch
+Patch1: 0001-ixgbe-Fix-memleak-in-ixgbe_configure_clsu32.patch
+Patch2: 0001-CP-47635-Fix-build-errors.patch
+Patch3: avoid-order-1-rx-buffers.patch
 
 BuildRequires: kernel-devel
 %{?_cov_buildrequires}
@@ -41,6 +45,13 @@ version %{kernel_version}.
 %{?_cov_prepare}
 
 %build
+# Generate kcompat_generated_defs.h
+chmod +x %{_builddir}/%{name}-%{version}/src/kcompat-generator.sh
+export KSRC=/lib/modules/%{kernel_version}/build
+export OUT=$(pwd)/src/kcompat_generated_defs.h
+export CONFIG_FILE=/lib/modules/%{kernel_version}/build/include/generated/autoconf.h
+bash %{_builddir}/%{name}-%{version}/src/kcompat-generator.sh
+
 %{?_cov_wrap} %{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src KSRC=/lib/modules/%{kernel_version}/build modules
 
 %install
@@ -68,6 +79,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Thu Dec 04 2025 Stephen Cheng <stephen.cheng@citrix.com> - 6.2.5-1
+- CP-310778: Upgrade ixgbe driver to version 6.2.5
+
 * Mon Jan 09 2023 Zhuangxuan Fei <zhuangxuan.fei@cloud.com> - 5.18.6-1
 - CP-41539: Upgrade ixgbe driver to version 5.18.6
 


### PR DESCRIPTION
Import new XS release from intel-ixgbe-6.2.5-1.xs8.src.rpm.
No conflicts.

---

### Work Item Reference

XCPNG-2826

---

### Why should this change be accepted as an update to XCP-ng?

Sync with XS release v6.2.5-1.
Fix memory leaks and build errors.

---

### Release Notes

#### Explain the change for users

Upgrade ixgbe driver to version 6.2.5. More Ethernet PCI Express 10 Gigabit Intel NIC devices are handled (E600 et E610 series).

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [X] No

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

None

_2. Regarding potential regressions._

Manual driver loading/unloading

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A

_2. To ensure there are no regressions._

N/A

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

N/A

_2. Regarding potential regressions._

N/A

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [X] No

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [X] No